### PR TITLE
feat(prettier): run prettier after eslint instead of relying on being part of eslint

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 module.exports = {
-  '*.{js,jsx,ts,tsx}': ['eslint --fix', 'git add'],
-  '*.json': ['prettier --write', 'git add'],
-  '*.html': ['prettier --write', 'git add'],
+  '*.{js,jsx,ts,tsx}': ['eslint --fix', 'prettier --write', 'git add'],
+  '*.{json,html}': ['prettier --write', 'git add'],
   '*.md': ['prettier --write', 'markdownlint', 'git add'],
 };


### PR DESCRIPTION
After https://github.com/weahead/eslint-config-react/pull/6 it now separates eslint and prettier. Prettier is no longer run as part of eslint, so we run them separately here too.